### PR TITLE
docs(search): exclude merchant parameter for instant search

### DIFF
--- a/source/includes/_search.md.erb
+++ b/source/includes/_search.md.erb
@@ -77,15 +77,28 @@ sdk.searchBlank()
 
 ### Query Parameters
 
-| Parameter    | Required | Description                                                                                                                                                                                                                                                                                     |
-|--------------|----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| did          | true     | Device ID. You get it from `init` method in SDK.                                                                                                                                                                                                                                                |
-| shop_id      | true     | Your API key.                                                                                                                                                                                                                                                                                   |
-| sid          | true     | Temporary user session ID.                                                                                                                                                                                                                                                                      |
-| type         | true     | In this case: "instant_search".                                                                                                                                                                                                                                                                 |
-| search_query | true     | Search query.                                                                                                                                                                                                                                                                                   |
-| locations    | false    | Comma separated list of locations IDs.                                                                                                                                                                                                                                                          |
-| search_scope | false    | The whitelist of parameters separated by commas. There are two types: common parameters and subparameters for books. If empty, all common parameters are considered included by default. If there are no book subparameters in the request, the search of book parameters won't be initialized. |
+| Parameter          | Required | Description                                                                                                                                                                                                                                                                                     |
+|--------------------|----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| did                | true     | Device ID. You get it from `init` method in SDK.                                                                                                                                                                                                                                                |
+| shop_id            | true     | Your API key.                                                                                                                                                                                                                                                                                   |
+| sid                | true     | Temporary user session ID.                                                                                                                                                                                                                                                                      |
+| type               | true     | In this case: "instant_search".                                                                                                                                                                                                                                                                 |
+| search_query       | true     | Search query.                                                                                                                                                                                                                                                                                   |
+| locations          | false    | Comma separated list of locations IDs.                                                                                                                                                                                                                                                          |
+| search_scope       | false    | The whitelist of parameters separated by commas. There are two types: common parameters and subparameters for books. If empty, all common parameters are considered included by default. If there are no book subparameters in the request, the search of book parameters won't be initialized. |
+| exclude_merchants* | false    | A comma-separated list of merchants. Products from these merchants will be excluded from the search results                                                                                                                                                                                     |
+
+<aside class="warning">
+
+<p></p>
+<p>* <code>exclude_merchants</code></p>
+<p>The <code>exclude_merchants</code> parameter works only in conjunction with the <code>merchants</code> parameter within the <code>locations</code> field.</p>
+<p>Note that if a product is associated with multiple merchants, the list of merchants in the <code>exclude_merchants</code> parameter must precisely match the list of merchants for that product. Otherwise, the parameter will not work.</p>
+<p>The connection between the <code>merchants</code> and <code>exclude_merchants</code> parameters exists because a whitelist of merchants is created based on the <code>merchants</code> parameter within the <code>locations</code> field.</p>
+<p>The whitelist of merchants is populated by the content of the <code>merchants</code> parameter. If this parameter is not provided, all merchants for the product will be included in the whitelist by default.</p>
+<p>The <code>exclude_merchants</code> parameter then excludes merchants from this whitelist.</p>
+
+</aside>
 
 ### Search_scope common parameters and the books subparameters
 


### PR DESCRIPTION
https://github.com/rees46/development/issues/2150
<details>

<summary>Пруф</summary>


<img width="1920" alt="proof 21" src="https://github.com/user-attachments/assets/664e11e3-2140-4d00-8787-141618e8e4b2" />


</details>

В этой задаче забыл сделать описание параметра для быстрого поиска. 